### PR TITLE
Update Buffer.md

### DIFF
--- a/guides/modules/Buffer/Buffer.md
+++ b/guides/modules/Buffer/Buffer.md
@@ -19,8 +19,8 @@ Allocate 8 `ui8` and pass that pointer into the buffer:
 
 
 ```mojo
-let p = DTypePointer[DType.ui8].alloc(8)
-let x = Buffer[8, DType.ui8](p)
+let p = DTypePointer[DType.uint8].alloc(8)
+let x = Buffer[8, DType.uint8](p)
 ```
 
 ## zero


### PR DESCRIPTION
let p = DTypePointer[DType.ui8].alloc(8)
let x = Buffer[8, DType.ui8](p)

Error:

Expression [21]:21:31: 'DType' value has no attribute 'ui8'
    let p = DTypePointer[DType.ui8].alloc(8)
                         ~~~~~^~~~

Expression [21]:22:28: 'DType' value has no attribute 'ui8'
    let x = Buffer[8, DType.ui8](p)
                      ~~~~~^~~~

Suggested Solution:

let p = DTypePointer[DType.uint8].alloc(8)
let x = Buffer[8, DType.uint8](p)

Explanation:
The error occurs because the attribute ui8 does not exist in the DType class. The correct attribute to use is uint8 instead. By replacing DType.ui8 with DType.uint8, the code should work as intended.