### PR TITLE
[feat] adding StringLiteral and StringRef types

### DIFF
--- a/guides/builtins/StringLiteral.md
+++ b/guides/builtins/StringLiteral.md
@@ -1,0 +1,153 @@
+---
+title: StringLiteral
+categories: Builtins
+usage: This type represents a string literal. String literals are all null-terminated for compatibility with C APIs, but this is subject to change. String literals store their length as an integer, and this does not include the null terminator.
+---
+
+Contributed by [Lorenzobattistela](https://github.com/Lorenzobattistela)
+
+# StringLiteral
+
+This type represents a string literal.
+
+String literals are all null-terminated for compatibility with C APIs, but this is subject to change. String literals store their length as an integer, and this does not include the null terminator.
+
+## aliases
+
+- `type = String`
+- `index = scalar<index>`
+
+
+## init
+
+```mojo
+var x : String = "Literal"
+print(x)
+
+var y = "StringLiteral"
+print(y)
+```
+
+    Literal
+    StringLiteral
+
+
+## fields
+
+- `value`: What is stored in the string literal.
+
+```mojo
+var my_string_lit = "test"
+print(my_string_lit.value)
+```
+
+    test
+
+
+## bool
+
+Convert the string to a boolean value. True if the string is not empty, false otherwise.
+
+```mojo
+var x = ""
+print(x.__bool__())
+
+var y = "a"
+print(y.__bool__())
+```
+
+    False
+    True
+
+
+## equal
+
+Compare the equality of two strings, receiving other StringLiteral as parameter. True if equal.
+
+```mojo
+var x = "abc"
+var y = "abc"
+var z = "ab"
+
+print(x.__eq__(y))
+print(x.__eq__(z))
+print(x == y)
+```
+
+    True
+    False
+    True
+
+
+## not equal
+
+Compare the inequality of two strings, receiving other StringLiteral as parameter. True if not equal.
+
+```mojo
+var x = "abc"
+var y = "abc"
+var z = "ab"
+
+print(x.__ne__(y))
+print(x.__ne__(z))
+print(x != y)
+```
+
+    False
+    True
+    False
+
+
+## add
+
+Concatenate two StringLiterals.
+
+```mojo
+let x = "hello "
+let y = "world"
+
+var c = x.__add__(y)
+var d = x + y
+
+print(c)
+print(d)
+```
+
+    hello world
+    hello world
+
+
+## len
+
+Return the length of the string.
+
+```mojo
+var x = "string"
+print(x.__len__())
+print(len(x))
+```
+
+    6
+    6
+
+
+## data
+
+Get raw pointer to the underlying data.
+
+`pointer<scalar<si8>>` is the return type of the method. It means that the method returns a pointer to the underlying data of the string literal. The `si8`` indicates that the data is a sequence of 8-bit signed integers, which is a common way to represent characters in a string.
+
+So, if you have a StringLiteral object, you can call data() on it to get a pointer to its underlying data. This could be useful if you need to pass the string data to a function that requires a pointer, or if you want to perform low-level operations on the string data.
+
+```mojo
+var x = "string"
+var y = x.data()
+x = "alo"
+print(y)
+print(x)
+```
+
+    string
+    alo
+
+<CommentService />

--- a/guides/builtins/StringRef.md
+++ b/guides/builtins/StringRef.md
@@ -1,0 +1,116 @@
+---
+title: StringRef
+categories: Builtins
+usage: Represent a constant reference to a string, i.e. a sequence of characters and a length, which need not be null terminated.
+---
+
+Contributed by [Lorenzobattistela](https://github.com/Lorenzobattistela)
+
+# StringRef
+
+Represent a constant reference to a string, i.e. a sequence of characters and a length, which need not be null terminated.
+
+## init
+
+```mojo
+var x = StringRef("a")
+print(x)
+```
+
+    a
+
+Or specifying the pointer
+
+```mojo
+let x = "string"
+let ptr = strLit.data()
+​
+let strRef = StringRef(ptr)
+```
+
+Or specifying the pointer and the length
+
+```mojo
+let x = "string"
+let ptr = strLit.data()
+let length = len(strLit)
+
+let strRef = StringRef(ptr, length)
+print(strRef.length)
+print(strRef.data)
+```
+
+    6
+    %zi (the pointer)
+
+## fields
+
+`data`: A pointer to the beginning of the string data being referenced.
+`length`: The length of the string being referenced.
+
+```mojo
+var a : StringRef = StringRef("a")
+print(a.data)
+print(a.length)
+```
+
+    a
+    1
+
+
+## getitem
+
+Get the string value at the specified position. It receives the index of the character to get. You can use the brackets notation to get the character at the specified position.
+
+```mojo
+var x = StringRef("hello")
+print(x.__getitem__(0))
+print(x[1])
+```
+
+    h
+    e
+
+
+## equal
+
+Compares two strings are equal.
+
+```mojo
+var x = StringRef("hello")
+var y = StringRef("hello")
+print(x.__eq__(y))
+print(x == y)
+```
+
+    True
+    True
+
+
+## not equal
+
+Compares two strings are not equal.
+
+```mojo
+var x = StringRef("hello")
+var y = StringRef("hello")
+print(x.__ne__(y))
+print(x != y)
+```
+
+    False
+    False
+
+
+## length
+
+Returns the length of the string.
+
+```mojo
+var x = StringRef("hello")
+print(x.__len__())
+print(len(x))
+```
+
+    5
+    5

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -129,6 +129,7 @@ export default defineUserConfig({
                                     '/guides/builtins/ListLiteral.md',
                                     '/guides/builtins/Tuple.md',
                                     '/guides/builtins/StringLiteral.md',
+                                    '/guides/builtins/StringRef.md',
                                 ]
                             },
                             {

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -127,7 +127,8 @@ export default defineUserConfig({
                                     '/guides/builtins/Bool.md',
                                     '/guides/builtins/FloatLiteral.md',
                                     '/guides/builtins/ListLiteral.md',
-                                    '/guides/builtins/Tuple.md'
+                                    '/guides/builtins/Tuple.md',
+                                    '/guides/builtins/StringLiteral.md',
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR refers to #36 

I finished writing the content. I noted that we have `.ipynb` notebooks of the markdown files. How can i provide the ipynb notebook to keep consistency as other builtins? I have it in my jupyter notebook on mojo's server, how can i download it?

Reviewer: @mojodojodev 
