### PR TITLE
Fix github link in setup.ipynb

### DIFF
--- a/guides/intro-to-mojo/setup.ipynb
+++ b/guides/intro-to-mojo/setup.ipynb
@@ -33,7 +33,7 @@
     "- Fill out the form, tick Mojo and press submit\n",
     "- In a few days you'll get an email with a button `Access the Mojo Playground`\n",
     "- If you want to access the playground from VS Code [follow this guide](/guides/general/mojo_playground_vscode.md)\n",
-    "- You can download these notebooks to run them locally [via Github](https://github.com/mojodojodev/mojodojo.dev/tree/main/guides/intro_to_mojo) \n",
+    "- You can download these notebooks to run them locally [via Github](https://github.com/mojodojodev/mojodojo.dev/tree/main/guides/intro-to-mojo) \n",
     "\n",
     "## Links\n",
     "- Join [the Modular Discord](https://discord.gg/modular)\n",


### PR DESCRIPTION
I found this guide is very useful and setup my VSCode to use the kernel.
Fixed this download link.